### PR TITLE
Introduce script for Cartesian checking

### DIFF
--- a/try_all.sh
+++ b/try_all.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rust_versions=( 1.{42..34}.0 )
+bitvec_versions=( 0.17.3 0.{16..10}.0 )
+
+explain ()
+{
+    echo "$@" "(Rust $rust_version and bitvec $bitvec_version)"
+}
+
+try_all ()
+{
+    for rust_version in "${rust_versions[@]}";
+    do
+        for bitvec_version in "${bitvec_versions[@]}";
+        do
+            (
+                set -e
+                rm -f Cargo.lock
+                rustup install $rust_version
+                cargo +$rust_version update --package bitvec --precise $bitvec_version
+            ) >&2 || {
+                explain "Update failed"
+                continue
+            };
+            cargo +$rust_version build --tests >&2 || {
+                explain "Build failed"
+                continue
+            };
+            cargo +$rust_version test >&2 && {
+                explain "Tests passed"
+            } || {
+                explain "Tests failed"
+            };
+        done;
+    done
+}
+
+try_all
+


### PR DESCRIPTION
```
$ ./try_all.sh  2> /dev/null
Tests failed (Rust 1.42.0 and bitvec 0.17.3)
Tests failed (Rust 1.42.0 and bitvec 0.16.0)
Tests failed (Rust 1.42.0 and bitvec 0.15.0)
Tests failed (Rust 1.42.0 and bitvec 0.14.0)
Tests failed (Rust 1.42.0 and bitvec 0.13.0)
Tests failed (Rust 1.42.0 and bitvec 0.12.0)
Tests failed (Rust 1.42.0 and bitvec 0.11.0)
Build failed (Rust 1.42.0 and bitvec 0.10.0)
Tests failed (Rust 1.41.0 and bitvec 0.17.3)
Tests failed (Rust 1.41.0 and bitvec 0.16.0)
Tests failed (Rust 1.41.0 and bitvec 0.15.0)
Tests failed (Rust 1.41.0 and bitvec 0.14.0)
Tests failed (Rust 1.41.0 and bitvec 0.13.0)
Tests failed (Rust 1.41.0 and bitvec 0.12.0)
Tests failed (Rust 1.41.0 and bitvec 0.11.0)
Build failed (Rust 1.41.0 and bitvec 0.10.0)
Tests failed (Rust 1.40.0 and bitvec 0.17.3)
Tests failed (Rust 1.40.0 and bitvec 0.16.0)
Tests failed (Rust 1.40.0 and bitvec 0.15.0)
Tests failed (Rust 1.40.0 and bitvec 0.14.0)
Tests failed (Rust 1.40.0 and bitvec 0.13.0)
Tests failed (Rust 1.40.0 and bitvec 0.12.0)
Tests failed (Rust 1.40.0 and bitvec 0.11.0)
Build failed (Rust 1.40.0 and bitvec 0.10.0)
Tests failed (Rust 1.39.0 and bitvec 0.17.3)
Tests failed (Rust 1.39.0 and bitvec 0.16.0)
Tests failed (Rust 1.39.0 and bitvec 0.15.0)
Tests failed (Rust 1.39.0 and bitvec 0.14.0)
Tests failed (Rust 1.39.0 and bitvec 0.13.0)
Tests failed (Rust 1.39.0 and bitvec 0.12.0)
Tests failed (Rust 1.39.0 and bitvec 0.11.0)
Build failed (Rust 1.39.0 and bitvec 0.10.0)
Tests failed (Rust 1.38.0 and bitvec 0.17.3)
Tests failed (Rust 1.38.0 and bitvec 0.16.0)
Tests failed (Rust 1.38.0 and bitvec 0.15.0)
Tests failed (Rust 1.38.0 and bitvec 0.14.0)
Tests failed (Rust 1.38.0 and bitvec 0.13.0)
Tests failed (Rust 1.38.0 and bitvec 0.12.0)
Tests failed (Rust 1.38.0 and bitvec 0.11.0)
Build failed (Rust 1.38.0 and bitvec 0.10.0)
Tests failed (Rust 1.37.0 and bitvec 0.17.3)
Tests failed (Rust 1.37.0 and bitvec 0.16.0)
Tests failed (Rust 1.37.0 and bitvec 0.15.0)
Tests failed (Rust 1.37.0 and bitvec 0.14.0)
Tests failed (Rust 1.37.0 and bitvec 0.13.0)
Tests failed (Rust 1.37.0 and bitvec 0.12.0)
Tests failed (Rust 1.37.0 and bitvec 0.11.0)
Build failed (Rust 1.37.0 and bitvec 0.10.0)
Tests failed (Rust 1.36.0 and bitvec 0.17.3)
Tests failed (Rust 1.36.0 and bitvec 0.16.0)
Tests failed (Rust 1.36.0 and bitvec 0.15.0)
Tests failed (Rust 1.36.0 and bitvec 0.14.0)
Tests failed (Rust 1.36.0 and bitvec 0.13.0)
Tests failed (Rust 1.36.0 and bitvec 0.12.0)
Tests failed (Rust 1.36.0 and bitvec 0.11.0)
Build failed (Rust 1.36.0 and bitvec 0.10.0)
Build failed (Rust 1.35.0 and bitvec 0.17.3)
Build failed (Rust 1.35.0 and bitvec 0.16.0)
Build failed (Rust 1.35.0 and bitvec 0.15.0)
Build failed (Rust 1.35.0 and bitvec 0.14.0)
Build failed (Rust 1.35.0 and bitvec 0.13.0)
Build failed (Rust 1.35.0 and bitvec 0.12.0)
Build failed (Rust 1.35.0 and bitvec 0.11.0)
Build failed (Rust 1.35.0 and bitvec 0.10.0)
Build failed (Rust 1.34.0 and bitvec 0.17.3)
Build failed (Rust 1.34.0 and bitvec 0.16.0)
Build failed (Rust 1.34.0 and bitvec 0.15.0)
Build failed (Rust 1.34.0 and bitvec 0.14.0)
Build failed (Rust 1.34.0 and bitvec 0.13.0)
Build failed (Rust 1.34.0 and bitvec 0.12.0)
Build failed (Rust 1.34.0 and bitvec 0.11.0)
Build failed (Rust 1.34.0 and bitvec 0.10.0)
```